### PR TITLE
✨ 유저 프로필 사진 추가, 📝 유저 탈퇴 기능 수정, 🐛 settings.py 토큰 경로 수정

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,8 @@ Django==4.2.1
 django-dotenv==1.4.2
 djangorestframework==3.14.0
 djangorestframework-simplejwt==5.2.2
+Pillow==9.5.0
 PyJWT==2.7.0
 pytz==2023.3
 sqlparse==0.4.4
+tzdata==2023.3

--- a/users/models.py
+++ b/users/models.py
@@ -41,7 +41,7 @@ class User(AbstractBaseUser):
 
     followings = models.ManyToManyField('self', symmetrical=False, blank=True, related_name="followers")
 
-    # image = models.ImageField()
+    image = models.ImageField(upload_to='%Y/%m/%d/', null=True)
 
     objects = UserManager()
 

--- a/users/serializers.py
+++ b/users/serializers.py
@@ -20,12 +20,11 @@ class UserSerializer(serializers.ModelSerializer):
 class UserProfileSerializer(serializers.ModelSerializer):
     followers = serializers.StringRelatedField(many=True, read_only = True)
     followings = serializers.StringRelatedField(many=True, read_only = True)
-    # article_set = ArticleListSerializer(many=True)
-    # like_articles = ArticleListSerializer(many=True)
+    # articles    
 
     class Meta:
         model = User
-        fields = ("nickname", "bio", "followings", "followers") # "article"
+        fields = ("nickname", "bio", "image", "followings", "followers") # "articles"
         
     
     def update(self, instance, validated_data):

--- a/users/urls.py
+++ b/users/urls.py
@@ -8,9 +8,9 @@ from django.urls import path
 urlpatterns = [
     path('signup/', views.SignupView.as_view(), name='signup'),
     path('mypage/', views.MypageView.as_view(), name='mypage'),
-    path('mock/', views.mockView.as_view(), name='mock_view'),
     path('login/', views.TokenObtainPairView.as_view(), name='token_obtain_pair'),
     path('refresh/', TokenRefreshView.as_view(), name='token_refresh'),
     path('<int:user_id>/', views.UserView.as_view(), name='user_view'),
     path('<int:user_id>/follow/', views.FollowView.as_view(), name='follow_view'),
 ]
+

--- a/users/views.py
+++ b/users/views.py
@@ -47,17 +47,9 @@ class UserView(APIView):
             return Response({"message":"본인의 프로필만 삭제할 수 있습니다."}, status=status.HTTP_403_FORBIDDEN)
         
         user = request.user
-        user.delete()
+        user.is_active = False
         return Response({"message": "회원 탈퇴 완료!"}, status=status.HTTP_200_OK)
     
-
-class mockView(APIView):
-    permission_classes = [permissions.IsAuthenticated]
-    def get(self, request):
-        user = request.user
-        user.save()
-        return Response("get 요청")
-
 
 class FollowView(APIView):
     def post(self, request, user_id):
@@ -65,7 +57,7 @@ class FollowView(APIView):
         me = request.user
         if me in you.followers.all():
             you.followers.remove(me)
-            return Response({"언팔로우"}, status=status.HTTP_200_OK)
+            return Response({"message":"언팔로우"}, status=status.HTTP_200_OK)
         else:
             you.followers.add(me)
-            return Response({"팔로우"}, status=status.HTTP_200_OK)
+            return Response({"message":"팔로우"}, status=status.HTTP_200_OK)

--- a/users/views.py
+++ b/users/views.py
@@ -48,6 +48,7 @@ class UserView(APIView):
         
         user = request.user
         user.is_active = False
+        user.save()
         return Response({"message": "회원 탈퇴 완료!"}, status=status.HTTP_200_OK)
     
 

--- a/yoriking/settings.py
+++ b/yoriking/settings.py
@@ -125,6 +125,10 @@ USE_TZ = True
 
 STATIC_URL = "static/"
 
+MEDIA_ROOT = BASE_DIR / 'media'
+MEDIA_URL = '/media/'
+
+
 # Default primary key field type
 # https://docs.djangoproject.com/en/4.2/ref/settings/#default-auto-field
 
@@ -142,5 +146,5 @@ SIMPLE_JWT = {
     "ACCESS_TOKEN_LIFETIME": timedelta(minutes=30),
     "REFRESH_TOKEN_LIFETIME": timedelta(days=1),
 
-    "TOKEN_OBTAIN_SERIALIZER": "rest_framework_simplejwt.serializers.TokenObtainPairSerializer",
+    "TOKEN_OBTAIN_SERIALIZER": "users.serializers.CustomTokenObtainPairSerializer",
 }

--- a/yoriking/urls.py
+++ b/yoriking/urls.py
@@ -16,6 +16,9 @@ Including another URLconf
 """
 from django.contrib import admin
 from django.urls import path, include
+from django.conf import settings
+from django.conf.urls.static import static
+
 
 urlpatterns = [
     path("admin/", admin.site.urls),
@@ -23,3 +26,6 @@ urlpatterns = [
     path("articles/", include("articles.urls")),
     path("joriking/", include("joriking.urls")),
 ]
+
+
+urlpatterns += static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)


### PR DESCRIPTION
✨ 유저 프로릴 사진 기능 추가
⚡ 유저 탈퇴 시 계정 삭제가 아닌 비활성화
⚡ settings.py에 CustomToken부분 수정


📝 requirements.txt
- Pillow 사용을 위해 수정

📝 settings.py
- ✨ image를 사용하기 위해 MEDIA 추가
- 🐛 TOKEN_OBTAIN_SERIALIZER의 경로 수정

✨  yoriking/urls.py
- 프로필 사진 기능을 위해 urlpatterns에 MEDIA 추가

✨ users/models.py
- 유저 프로필 사진 기능 추가

✨ users/serializers.py
- 추가된 image를 field에 추가하여 reponse로 받게 설정

📝 users/views.py
- 📝 계정 탈퇴 시 계정 삭제가 아닌 비활성화로 수정
- 🔥 mockView 삭제
- 📝 follow, unfollow 부분 api설계에 맞춰 수정

🔥 users/urls.py
- mock 삭제

 
